### PR TITLE
Performance refactor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7321,8 +7321,7 @@
     "ini": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-      "dev": true
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "inquirer": {
       "version": "3.0.6",
@@ -8863,8 +8862,7 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "minipass": {
       "version": "3.1.3",
@@ -11921,9 +11919,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sartography-workflow-lib": {
-      "version": "0.0.447",
-      "resolved": "https://registry.npmjs.org/sartography-workflow-lib/-/sartography-workflow-lib-0.0.447.tgz",
-      "integrity": "sha512-xGBS1YQbXKj3O3I8bK58m7D2NApUpZUuzE3FxLTjS52Q1FL6Hgw2GY8urTJ/BF0a4ROEIHUaPm/4BN9yuzx33w=="
+      "version": "0.0.469",
+      "resolved": "https://registry.npmjs.org/sartography-workflow-lib/-/sartography-workflow-lib-0.0.469.tgz",
+      "integrity": "sha512-enqTBvU829XGjCpW7kvnWOYj4caslc86cozrCgeTqZhiJhDfzpYlBaP0BXqx+j2BQ4hXq4q12wzZmY2lZYJXDA=="
     },
     "sass": {
       "version": "1.26.3",
@@ -15423,8 +15421,7 @@
     "y18n": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
-      "dev": true
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
     },
     "yallist": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "ngx-markdown": "^9.1.1",
     "protractor": "^7.0.0",
     "rxjs": "~6.5.4",
-    "sartography-workflow-lib": "0.0.447",
+    "sartography-workflow-lib": "0.0.469",
     "tslib": "^1.13.0",
     "uuid": "^7.0.2",
     "zone.js": "^0.10.3"

--- a/src/app/_dialogs/open-file-dialog/open-file-dialog.component.spec.ts
+++ b/src/app/_dialogs/open-file-dialog/open-file-dialog.component.spec.ts
@@ -9,7 +9,7 @@ import {MatInputModule} from '@angular/material/input';
 import {BrowserAnimationsModule, NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {Router} from '@angular/router';
 import {RouterTestingModule} from '@angular/router/testing';
-import {ApiService, MockEnvironment, mockFileMeta0} from 'sartography-workflow-lib';
+import {ApiService, MockEnvironment, mockFile0, mockFileMeta0} from 'sartography-workflow-lib';
 import {OpenFileDialogData} from '../../_interfaces/dialog-data';
 
 import { OpenFileDialogComponent } from './open-file-dialog.component';
@@ -78,14 +78,14 @@ describe('OpenFileDialogComponent', () => {
 
   it('should save data on submit', () => {
     const closeSpy = spyOn(component.dialogRef, 'close').and.stub();
-    component.data.file = mockFileMeta0.file;
+    component.data.file = mockFile0;
     component.onSubmit();
     expect(closeSpy).toHaveBeenCalledWith(component.data);
   });
 
   it('should not change data on cancel', () => {
     const closeSpy = spyOn(component.dialogRef, 'close').and.stub();
-    const expectedData: OpenFileDialogData = { file: mockFileMeta0.file };
+    const expectedData: OpenFileDialogData = { file: mockFile0 };
 
     component.data.file = expectedData.file;
     component.onNoClick();
@@ -111,14 +111,14 @@ describe('OpenFileDialogComponent', () => {
     component.data.file = undefined;
     expect(component.getFileName()).toEqual('Click to select a file');
 
-    component.data.file = mockFileMeta0.file;
-    expect(component.getFileName()).toEqual(mockFileMeta0.file.name);
+    component.data.file = mockFile0;
+    expect(component.getFileName()).toEqual(mockFile0.name);
   });
 
   it('should get a file from the file input field event', () => {
-    const event = {target: {files: [mockFileMeta0.file]}};
+    const event = {target: {files: [mockFile0]}};
     (component as any).onFileSelected(event);
-    expect(component.data.file).toEqual(mockFileMeta0.file);
+    expect(component.data.file).toEqual(mockFile0);
   });
 
   it('should determine if a string is a valid URL', () => {

--- a/src/app/file-list/file-list.component.html
+++ b/src/app/file-list/file-list.component.html
@@ -16,8 +16,8 @@
           Primary process
         </button>
       </ng-container>
-      <h4 (click)="editFile(fm)" mat-line>{{fm.file.name}}</h4>
-      <p (click)="editFile(fm)" mat-line> Updated: {{fm.file.lastModified | date}}</p>
+      <h4 (click)="editFile(fm)" mat-line>{{fm.name}}</h4>
+      <p (click)="editFile(fm)" mat-line> Updated: {{fm.last_modified | date:'medium'}}</p>
       <button (click)="downloadFile(fm)" class="mat-elevation-z0" color="primary" mat-icon-button>
         <mat-icon>save_alt</mat-icon>
       </button>

--- a/src/app/file-list/file-list.component.ts
+++ b/src/app/file-list/file-list.component.ts
@@ -112,13 +112,12 @@ export class FileListComponent implements OnInit, OnChanges {
           content_type: data.file.type,
           name: data.file.name,
           type: getFileType(data.file),
-          file: data.file,
           workflow_spec_id: this.workflowSpec.id,
         };
 
         if (isNumberDefined(data.fileMetaId)) {
           // Update existing file
-          this.api.updateFileData(newFileMeta).subscribe(() => {
+          this.api.updateFileData(newFileMeta, data.file).subscribe(() => {
             this._loadFileMetas();
           });
         } else {
@@ -127,7 +126,7 @@ export class FileListComponent implements OnInit, OnChanges {
             workflow_spec_id: this.workflowSpec.id,
           };
 
-          this.api.addFileMeta(fileParams, newFileMeta).subscribe(dbFm => {
+          this.api.addFile(fileParams, newFileMeta, data.file).subscribe(dbFm => {
             this._loadFileMetas();
           });
         }
@@ -146,15 +145,6 @@ export class FileListComponent implements OnInit, OnChanges {
   private _loadFileMetas() {
     this.api.getFileMetas({workflow_spec_id: this.workflowSpec.id}).subscribe(fms => {
       this.fileMetas = fms.sort((a, b) => (a.name > b.name) ? 1 : -1);
-      this._loadFileData();
-    });
-  }
-
-  private _loadFileData() {
-    this.fileMetas.forEach(fm => {
-      this.api.getFileData(fm.id).subscribe(response => {
-        fm.file = newFileFromResponse(fm, response);
-      });
     });
   }
 

--- a/src/app/modeler/modeler.component.html
+++ b/src/app/modeler/modeler.component.html
@@ -30,7 +30,7 @@
     <mat-menu #importMenu="matMenu">
       <button mat-menu-item (click)="openMethod = 'db'" [matMenuTriggerFor]="dbMenu" title="Open diagram from database">
         <mat-icon>cloud</mat-icon>
-        Open previously saved...
+        Open related BPMN/DMN File ...
       </button>
       <mat-menu #dbMenu="matMenu">
         <a

--- a/src/app/modeler/modeler.component.spec.ts
+++ b/src/app/modeler/modeler.component.spec.ts
@@ -1,4 +1,4 @@
-import {APP_BASE_HREF} from '@angular/common';
+import {APP_BASE_HREF, DatePipe} from '@angular/common';
 import {HttpErrorResponse, HttpHeaders, HttpResponse} from '@angular/common/http';
 import {HttpClientTestingModule, HttpTestingController} from '@angular/common/http/testing';
 import {DebugNode} from '@angular/core';
@@ -431,11 +431,14 @@ describe('ModelerComponent', () => {
   it('should get file metadata tooltip text', () => {
     component.workflowSpec = undefined;
     expect(component.getFileMetaTooltipText(mockFileMeta0)).toEqual('Loading...');
+    mockFileMeta0.type = FileType.BPMN;
+    mockFileMeta0.last_modified = '2020-01-23T12:34:12.345Z';
+    const lastUpdated = new DatePipe('en-us').transform(mockFileMeta0.last_modified, 'medium');
 
     component.workflowSpec = mockWorkflowSpec0;
     const expectedString = `
           File name: one-fish.bpmn
-          Last updated: Jan 23, 2020, 7:34:12 AM
+          Last updated: ${lastUpdated}
           Version: 1.0
       `;
     mockFileMeta0.type = FileType.BPMN;

--- a/src/app/modeler/modeler.component.spec.ts
+++ b/src/app/modeler/modeler.component.spec.ts
@@ -24,12 +24,13 @@ import {
   FileMeta,
   FileType,
   MockEnvironment,
+  mockFile0,
   mockFileMeta0,
   mockFileMetas,
   mockWorkflowSpec0,
   mockWorkflowSpecs
 } from 'sartography-workflow-lib';
-import {BPMN_DIAGRAM, BPMN_DIAGRAM_EMPTY, BPMN_DIAGRAM_WITH_WARNINGS} from '../../testing/mocks/diagram.mocks';
+import {BPMN_DIAGRAM, BPMN_DIAGRAM_EMPTY} from '../../testing/mocks/diagram.mocks';
 import {FileMetaDialogComponent} from '../_dialogs/file-meta-dialog/file-meta-dialog.component';
 import {NewFileDialogComponent} from '../_dialogs/new-file-dialog/new-file-dialog.component';
 import {OpenFileDialogComponent} from '../_dialogs/open-file-dialog/open-file-dialog.component';
@@ -132,14 +133,10 @@ describe('ModelerComponent', () => {
     expect(req.request.method).toEqual('GET');
     req.flush(mockFileMetas);
 
-    mockFileMetas.forEach((fm, i) => {
-      const fmReq = httpMock.expectOne(`apiRoot/file/${fm.id}/data`);
-      const mockHeaders = new HttpHeaders()
-        .append('last-modified', mockFileMetas[i].file.lastModified.toString())
-        .append('content-type', mockFileMetas[i].content_type);
-      expect(fmReq.request.method).toEqual('GET');
-      fmReq.flush(new ArrayBuffer(8), {headers: mockHeaders});
-    });
+    const fmReq = httpMock.expectOne(`apiRoot/file/${mockFileMeta0.id}/data`);
+
+
+
   });
 
   afterEach(() => {
@@ -225,8 +222,8 @@ describe('ModelerComponent', () => {
   it('should get the diagram file name', () => {
     expect(component.getFileName()).toEqual(mockFileMeta0.name);
 
-    const filename = 'expected_file_name.jpg';
-    component.diagramFile = new File([], filename, {type: 'image/jpeg'});
+    const filename = 'one-fish.bpmn';
+    component.diagramFileMeta.name = filename;
     expect(component.getFileName()).toEqual(filename);
   });
 
@@ -291,7 +288,7 @@ describe('ModelerComponent', () => {
     component.diagramComponent.writeValue(BPMN_DIAGRAM_EMPTY.replace(/REPLACE_ME/g, 'cream_colored_ponies'));
     component.saveFileChanges();
 
-    expect(updateFileDataSpy).toHaveBeenCalledWith(mockFileMeta0);
+    expect(updateFileDataSpy).toHaveBeenCalledWith(mockFileMeta0, mockFile0);
     expect(snackBarOpenSpy).toHaveBeenCalled();
   });
 
@@ -318,12 +315,11 @@ describe('ModelerComponent', () => {
     const updateFileMetaSpy = spyOn(component.api, 'updateFileMeta')
       .and.returnValue(of(mockFileMeta0));
     const updateFileDataSpy = spyOn(component.api, 'updateFileData')
-      .and.returnValue(of(mockFileMeta0.file));
+      .and.returnValue(of(mockFile0));
     const loadFilesFromDbSpy = spyOn(component, 'loadFilesFromDb').and.stub();
     const snackBarSpy = spyOn(component.snackBar, 'open').and.stub();
     const noDateOrVersion: FileMeta = {
       content_type: mockFileMeta0.content_type,
-      file: mockFileMeta0.file,
       id: mockFileMeta0.id,
       name: mockFileMeta0.name,
       type: mockFileMeta0.type,
@@ -334,7 +330,7 @@ describe('ModelerComponent', () => {
     component._upsertFileMeta(data);
     expect(component.xml).toEqual(newXml);
     expect(updateFileMetaSpy).toHaveBeenCalledWith(noDateOrVersion);
-    expect(updateFileDataSpy).toHaveBeenCalledWith(noDateOrVersion);
+    expect(updateFileDataSpy).toHaveBeenCalledWith(noDateOrVersion, mockFile0);
     expect(loadFilesFromDbSpy).toHaveBeenCalled();
     expect(snackBarSpy).toHaveBeenCalled();
   });
@@ -349,13 +345,12 @@ describe('ModelerComponent', () => {
     const noDateOrVersion: FileMeta = {
       id: undefined,
       content_type: mockFileMeta0.content_type,
-      file: mockFileMeta0.file,
       name: mockFileMeta0.name,
       type: mockFileMeta0.type,
       workflow_spec_id: mockFileMeta0.workflow_spec_id,
     };
 
-    const addFileMetaSpy = spyOn(component.api, 'addFileMeta')
+    const addFileMetaSpy = spyOn(component.api, 'addFile')
       .and.returnValue(of(mockFileMeta0));
     const loadFilesFromDbSpy = spyOn(component, 'loadFilesFromDb').and.stub();
     const routerNavigateSpy = spyOn(component.router, 'navigate').and.stub();
@@ -367,7 +362,7 @@ describe('ModelerComponent', () => {
     component.draftXml = newXml;
     component._upsertFileMeta(data);
     expect(component.xml).toEqual(newXml);
-    expect(addFileMetaSpy).toHaveBeenCalledWith({workflow_spec_id: mockWorkflowSpec0.id}, noDateOrVersion);
+    expect(addFileMetaSpy).toHaveBeenCalledWith({workflow_spec_id: mockWorkflowSpec0.id}, noDateOrVersion, mockFile0);
     expect(loadFilesFromDbSpy).not.toHaveBeenCalled();
     expect(routerNavigateSpy).toHaveBeenCalled();
     expect(snackBarSpy).toHaveBeenCalled();
@@ -375,7 +370,7 @@ describe('ModelerComponent', () => {
 
   it('should load files from the database', () => {
     const mockHeaders = new HttpHeaders()
-      .append('last-modified', mockFileMeta0.file.lastModified.toString())
+      .append('last-modified', mockFileMeta0.last_modified.toString())
       .append('content-type', mockFileMeta0.content_type);
     const mockResponse = new HttpResponse<ArrayBuffer>({
       body: new ArrayBuffer(8),
@@ -394,9 +389,6 @@ describe('ModelerComponent', () => {
     expect(component.workflowSpec).toEqual(mockWorkflowSpec0);
     expect(getFileMetasSpy).toHaveBeenCalledWith({workflow_spec_id: mockWorkflowSpec0.id});
 
-    mockFileMetas.forEach(fm => {
-      expect(getFileDataSpy).toHaveBeenCalledWith(fm.id);
-    });
 
     expect(component.bpmnFiles.length).toEqual(mockFileMetas.length);
   });
@@ -404,8 +396,8 @@ describe('ModelerComponent', () => {
   it('should load a database file', () => {
     const onSubmitFileToOpenSpy = spyOn(component, 'onSubmitFileToOpen').and.stub();
     component.workflowSpecs = mockWorkflowSpecs;
-    component.loadDbFile(mockFileMeta0);
-    expect(component.diagramFile).toEqual(mockFileMeta0.file);
+    component.loadDbFile(mockFileMeta0, mockFile0);
+    expect(component.diagramFile).toEqual(mockFile0);
     expect(component.diagramFileMeta).toEqual(mockFileMeta0);
     expect(component.workflowSpec).toEqual(mockWorkflowSpec0);
     expect(onSubmitFileToOpenSpy).toHaveBeenCalled();
@@ -415,7 +407,7 @@ describe('ModelerComponent', () => {
     component.xml = BPMN_DIAGRAM_EMPTY.replace(/REPLACE_ME/g, 'sleigh_bells');
     component.draftXml = BPMN_DIAGRAM_EMPTY.replace(/REPLACE_ME/g, 'schnitzel_with_noodles');
     component.diagramFileMeta = mockFileMeta0;
-    component.diagramFile = mockFileMeta0.file;
+    component.diagramFile = mockFile0;
     component.workflowSpec = mockWorkflowSpec0;
     component.newDiagram();
 
@@ -430,13 +422,9 @@ describe('ModelerComponent', () => {
 
   it('should get a file metadata display string', () => {
     expect(component.getFileMetaDisplayString(undefined)).toEqual('Loading...');
-    const expectedString = 'one-fish.bpmn - v1.0 (Jan 23, 2020)';
-
-    const file = new File([], 'one-fish.bpmn', {
-      type: 'text/xml',
-      lastModified: new Date('2020-01-23T12:34:12.345Z').getTime(),
-    });
-    mockFileMeta0.file = file;
+    const expectedString = 'one-fish.bpmn';
+    mockFileMeta0.type = FileType.BPMN;
+    mockFileMeta0.last_modified = '2020-01-23T12:34:12.345Z';
     expect(component.getFileMetaDisplayString(mockFileMeta0)).toEqual(expectedString);
   });
 
@@ -446,20 +434,12 @@ describe('ModelerComponent', () => {
 
     component.workflowSpec = mockWorkflowSpec0;
     const expectedString = `
-          Workflow spec ID: all_things
-          Workflow name: all_things
-          Display name: Everything
-          Description: Do all the things
           File name: one-fish.bpmn
-          Last updated: Jan 23, 2020
+          Last updated: Jan 23, 2020, 7:34:12 AM
           Version: 1.0
       `;
-
-    const file = new File([], 'one-fish.bpmn', {
-      type: 'text/xml',
-      lastModified: new Date('2020-01-23T12:34:12.345Z').getTime(),
-    });
-    mockFileMeta0.file = file;
+    mockFileMeta0.type = FileType.BPMN;
+    mockFileMeta0.last_modified = '2020-01-23T12:34:12.345Z';
     expect(component.getFileMetaTooltipText(mockFileMeta0)).toEqual(expectedString);
   });
 
@@ -478,7 +458,7 @@ describe('ModelerComponent', () => {
 
   it('should display open file dialog', () => {
     const data: OpenFileDialogData = {
-      file: mockFileMeta0.file
+      file: mockFile0
     };
     const expectedFile = new File([], mockFileMeta0.name, {type: mockFileMeta0.content_type});
     const event = {target: {files: [expectedFile]}};

--- a/src/app/reference-files/reference-files.component.spec.ts
+++ b/src/app/reference-files/reference-files.component.spec.ts
@@ -12,7 +12,7 @@ import {RouterTestingModule} from '@angular/router/testing';
 import * as FileSaver from 'file-saver';
 import createClone from 'rfdc';
 import {of} from 'rxjs';
-import {ApiService, FileMeta, FileType, MockEnvironment, mockFileMetaReference0} from 'sartography-workflow-lib';
+import {ApiService, FileMeta, FileType, MockEnvironment, mockFileMetaReference0, mockFileReference0} from 'sartography-workflow-lib';
 import {OpenFileDialogComponent} from '../_dialogs/open-file-dialog/open-file-dialog.component';
 import {ReferenceFilesComponent} from './reference-files.component';
 
@@ -26,9 +26,12 @@ describe('ReferenceFilesComponent', () => {
   const mockDocMeta: FileMeta = createClone()(mockFileMetaReference0);
   mockDocMeta.type = FileType.XLSX;
 
+  const timeString = '2020-01-23T12:34:12.345Z';
+  const timeCode = new Date(timeString).getTime();
+
   const expectedFile = new File([], mockDocMeta.name, {
     type: mockDocMeta.content_type,
-    lastModified: mockDocMeta.file.lastModified
+    lastModified: timeCode
   });
 
   const mockHeaders = new HttpHeaders()
@@ -101,7 +104,7 @@ describe('ReferenceFilesComponent', () => {
       .and.returnValue({
         afterClosed: () => of({
           fileMetaId: mockFileMetaReference0.id,
-          file: mockFileMetaReference0.file
+          file: mockFileReference0
         })
       } as any);
     const _loadReferenceFilesSpy = spyOn((component as any), '_loadReferenceFiles').and.stub();

--- a/src/app/workflow-spec-list/workflow-spec-list.component.html
+++ b/src/app/workflow-spec-list/workflow-spec-list.component.html
@@ -33,7 +33,7 @@
 
         <div *ngIf="!(searchField.value && cat.workflow_specs.length === 0)">
         <ng-container *ngIf="!(cat.id === null && cat.workflow_specs.length === 0)">
-          <mat-expansion-panel hideToggle (opened)="selectCat(cat)" [expanded]="selectedSpec.category_id == cat.id">
+          <mat-expansion-panel hideToggle (opened)="selectCat(cat)" [expanded]="isSelected(cat)">
             <mat-expansion-panel-header>
               <mat-panel-title>
                 {{cat.display_name}}

--- a/src/app/workflow-spec-list/workflow-spec-list.component.ts
+++ b/src/app/workflow-spec-list/workflow-spec-list.component.ts
@@ -91,6 +91,10 @@ export class WorkflowSpecListComponent implements OnInit {
     this.selectedCat = selectedCat;
   }
 
+  isSelected(cat: WorkflowSpecCategory) {
+    return this.selectedCat && this.selectedCat === cat;
+  }
+
   selectSpec(selectedSpec?: WorkflowSpec) {
     this.selectedSpec = selectedSpec;
     this.location.replaceState(environment.homeRoute + '/' + selectedSpec.name);


### PR DESCRIPTION
largely around assuring that we only download files when we need the data, and using file-meta information at all other times.

Clarifying in the [open] dialog that you can open up any other file related to the current workflow.