### PR TITLE
Set the `standalone` parameter to `required`. #323

### DIFF
--- a/src/app/_dialogs/workflow-spec-dialog/workflow-spec-dialog.component.ts
+++ b/src/app/_dialogs/workflow-spec-dialog/workflow-spec-dialog.component.ts
@@ -97,6 +97,7 @@ export class WorkflowSpecDialogComponent {
           templateOptions: {
             label: 'Standalone',
             description: 'Is this a standalone workflow?',
+            required: true,
           },
         },
       ];


### PR DESCRIPTION
This fixes a problem when creating workflow specs where the new spec was not created if standalone was not set.

Dan: All the unit tests pass, but I am still not able to run e2e tests on my laptop.