### PR TITLE
Removes 'required' property from checkboxes, makes them false by default

### DIFF
--- a/src/app/_dialogs/workflow-spec-dialog/workflow-spec-dialog.component.ts
+++ b/src/app/_dialogs/workflow-spec-dialog/workflow-spec-dialog.component.ts
@@ -91,22 +91,20 @@ export class WorkflowSpecDialogComponent {
         {
           key: 'standalone',
           type: 'checkbox',
-          defaultValue: this.data.standalone,
+          defaultValue: false,
           templateOptions: {
             label: 'Standalone',
             description: 'Is this a standalone workflow?',
-            required: true,
             indeterminate: false,
           },
         },
         {
           key: 'library',
           type: 'checkbox',
-          defaultValue: this.data.library,
+          defaultValue: false,
           templateOptions: {
             label: 'Library',
             description: 'Is this a library workflow?',
-            required: true,
             indeterminate: false,
           },
         },
@@ -115,6 +113,7 @@ export class WorkflowSpecDialogComponent {
   }
 
   onNoClick() {
+    console.log('form model : ', this.model);
     this.dialogRef.close();
   }
 

--- a/src/app/_dialogs/workflow-spec-dialog/workflow-spec-dialog.component.ts
+++ b/src/app/_dialogs/workflow-spec-dialog/workflow-spec-dialog.component.ts
@@ -91,7 +91,7 @@ export class WorkflowSpecDialogComponent {
         {
           key: 'standalone',
           type: 'checkbox',
-          defaultValue: false,
+          defaultValue: this.data.standalone ? this.data.standalone : false,
           templateOptions: {
             label: 'Standalone',
             description: 'Is this a standalone workflow?',
@@ -101,7 +101,7 @@ export class WorkflowSpecDialogComponent {
         {
           key: 'library',
           type: 'checkbox',
-          defaultValue: false,
+          defaultValue: this.data.library ? this.data.library : false,
           templateOptions: {
             label: 'Library',
             description: 'Is this a library workflow?',


### PR DESCRIPTION
note - originally i wrote this ticket to also check if both `standalone` and `library` were checked, to invalidate the form; in the future there may be other workflow spec states other than just these two. So i do not want to hard code that into form validation right now :-)