### PR TITLE
Bug/resort refactor 435

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "ngx-markdown": "^12.0.1",
     "protractor": "^7.0.0",
     "rxjs": "^6.5.3",
-    "sartography-workflow-lib": "^0.0.547",
+    "sartography-workflow-lib": "^0.0.555",
     "tslib": "^2.3.0",
     "uuid": "^8.3.2",
     "zone.js": "^0.11.4"

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "ngx-markdown": "^12.0.1",
     "protractor": "^7.0.0",
     "rxjs": "^6.5.3",
-    "sartography-workflow-lib": "^0.0.555",
+    "sartography-workflow-lib": "^0.0.556",
     "tslib": "^2.3.0",
     "uuid": "^8.3.2",
     "zone.js": "^0.11.4"

--- a/src/app/_dialogs/workflow-spec-category-dialog/workflow-spec-category-dialog.component.ts
+++ b/src/app/_dialogs/workflow-spec-category-dialog/workflow-spec-category-dialog.component.ts
@@ -3,7 +3,7 @@ import {FormGroup} from '@angular/forms';
 import {MAT_DIALOG_DATA, MatDialogRef} from '@angular/material/dialog';
 import {FormlyFieldConfig, FormlyFormOptions} from '@ngx-formly/core';
 import {toSnakeCase} from 'sartography-workflow-lib';
-import {WorkflowSpecCategoryDialogData, WorkflowSpecDialogData} from '../../_interfaces/dialog-data';
+import {WorkflowSpecCategoryDialogData} from '../../_interfaces/dialog-data';
 
 @Component({
   selector: 'app-workflow-spec-category-dialog',
@@ -47,18 +47,6 @@ export class WorkflowSpecCategoryDialogComponent {
         placeholder: 'Title of the workflow spec category',
         description: 'This is a human-readable title for the workflow spec category,' +
           'which should be easy for others to read and remember.',
-        required: true,
-      },
-    },
-    {
-      key: 'display_order',
-      type: 'input',
-      defaultValue: this.data.display_order,
-      templateOptions: {
-        type: 'number',
-        label: 'Display Order',
-        placeholder: 'Order in which category will be displayed',
-        description: 'Sort order that the category should appear in. Lower numbers will appear first.',
         required: true,
       },
     },

--- a/src/app/workflow-spec-list/workflow-spec-list.component.html
+++ b/src/app/workflow-spec-list/workflow-spec-list.component.html
@@ -76,11 +76,11 @@
               </button>
             </mat-expansion-panel-header>
             <mat-list>
-              <mat-list-item *ngFor="let wfs of cat.workflow_specs" class="workflow-spec" fxLayout="row" fxLayoutGap="10px" fxLayoutAlign="start center">
+              <mat-list-item *ngFor="let wfs of cat.workflow_specs; let i = index" class="workflow-spec" fxLayout="row" fxLayoutGap="10px" fxLayoutAlign="start center">
                 <span [ngClass]="{'spec_menu_item':true, 'spec-selected': selectedSpec && wfs.id === selectedSpec.id}" (click)="selectSpec(wfs)">{{wfs.display_name}}</span>
-                <span class="spec-actions" fxLayout="row" fxLayoutGap="10px" *ngIf="cat && cat.id !== null">
+                <span class="spec-actions" fxLayout="row" fxLayoutGap="10px" *ngIf="cat.id !== null && cat">
                 <button
-                  *ngIf="cat && cat.workflow_specs.length > 0 && wfs.display_order !== 0"
+                  *ngIf="i!==0 && cat.workflow_specs.length > 0"
                   mat-icon-button
                   title="Move up"
                   color="primary"
@@ -89,7 +89,7 @@
                   <mat-icon>arrow_upward</mat-icon>
                 </button>
                 <button
-                  *ngIf="cat && cat.workflow_specs.length > 0 && (wfs.display_order < cat.workflow_specs.length - 1)"
+                  *ngIf="i!==cat.workflow_specs.length-1 && cat.workflow_specs.length > 0"
                   mat-icon-button
                   title="Move down"
                   color="primary"

--- a/src/app/workflow-spec-list/workflow-spec-list.component.html
+++ b/src/app/workflow-spec-list/workflow-spec-list.component.html
@@ -114,7 +114,7 @@
                 mat-mini-fab
                 title="Move up"
                 color="primary"
-                (click)="editCategoryDisplayOrder(cat, cat.id, 'up')"
+                (click)="editCategoryDisplayOrder(cat.id, 'up')"
               >
                 <mat-icon>arrow_upward</mat-icon>
               </button>
@@ -123,7 +123,7 @@
                 mat-mini-fab
                 title="Move down"
                 color="primary"
-                (click)="editCategoryDisplayOrder(cat, cat.id, 'down')"
+                (click)="editCategoryDisplayOrder(cat.id, 'down')"
               >
                 <mat-icon>arrow_downward</mat-icon>
               </button>

--- a/src/app/workflow-spec-list/workflow-spec-list.component.html
+++ b/src/app/workflow-spec-list/workflow-spec-list.component.html
@@ -84,7 +84,7 @@
                   mat-icon-button
                   title="Move up"
                   color="primary"
-                  (click)="editSpecDisplayOrder(wfs && wfs.id, -1)"
+                  (click)="editSpecDisplayOrder(cat, wfs.id, 'up')"
                 >
                   <mat-icon>arrow_upward</mat-icon>
                 </button>
@@ -93,7 +93,7 @@
                   mat-icon-button
                   title="Move down"
                   color="primary"
-                  (click)="editSpecDisplayOrder(wfs.id, 1)"
+                  (click)="editSpecDisplayOrder(cat, wfs.id, 'down')"
                 >
                   <mat-icon>arrow_downward</mat-icon>
                 </button>

--- a/src/app/workflow-spec-list/workflow-spec-list.component.html
+++ b/src/app/workflow-spec-list/workflow-spec-list.component.html
@@ -110,7 +110,7 @@
                 <mat-icon>edit</mat-icon>
               </button>
               <button
-                *ngIf="cat.display_order > 0"
+                *ngIf="!cat[0]"
                 mat-mini-fab
                 title="Move up"
                 color="primary"
@@ -119,7 +119,7 @@
                 <mat-icon>arrow_upward</mat-icon>
               </button>
               <button
-                *ngIf="cat.display_order < workflowSpecsByCategory.length - 2"
+                *ngIf="!cat[workflowSpecsByCategory.length-1]"
                 mat-mini-fab
                 title="Move down"
                 color="primary"

--- a/src/app/workflow-spec-list/workflow-spec-list.component.html
+++ b/src/app/workflow-spec-list/workflow-spec-list.component.html
@@ -84,7 +84,7 @@
                   mat-icon-button
                   title="Move up"
                   color="primary"
-                  (click)="editSpecDisplayOrder(wfs && wfs.id, -1, cat.workflow_specs)"
+                  (click)="editSpecDisplayOrder(wfs && wfs.id, -1)"
                 >
                   <mat-icon>arrow_upward</mat-icon>
                 </button>
@@ -93,7 +93,7 @@
                   mat-icon-button
                   title="Move down"
                   color="primary"
-                  (click)="editSpecDisplayOrder(wfs.id, 1, cat.workflow_specs)"
+                  (click)="editSpecDisplayOrder(wfs.id, 1)"
                 >
                   <mat-icon>arrow_downward</mat-icon>
                 </button>
@@ -114,7 +114,7 @@
                 mat-mini-fab
                 title="Move up"
                 color="primary"
-                (click)="editCategoryDisplayOrder(cat.id, -1, workflowSpecsByCategory)"
+                (click)="editCategoryDisplayOrder(cat.id, -1)"
               >
                 <mat-icon>arrow_upward</mat-icon>
               </button>
@@ -123,7 +123,7 @@
                 mat-mini-fab
                 title="Move down"
                 color="primary"
-                (click)="editCategoryDisplayOrder(cat.id, 1, workflowSpecsByCategory)"
+                (click)="editCategoryDisplayOrder(cat.id, 1)"
               >
                 <mat-icon>arrow_downward</mat-icon>
               </button>

--- a/src/app/workflow-spec-list/workflow-spec-list.component.html
+++ b/src/app/workflow-spec-list/workflow-spec-list.component.html
@@ -110,7 +110,7 @@
                 <mat-icon>edit</mat-icon>
               </button>
               <button
-                *ngIf="j!==1"
+                *ngIf="j!==0"
                 mat-mini-fab
                 title="Move up"
                 color="primary"
@@ -119,7 +119,7 @@
                 <mat-icon>arrow_upward</mat-icon>
               </button>
               <button
-                *ngIf="j!== cat[workflowSpecsByCategory.length-1]"
+                *ngIf="j!== workflowSpecsByCategory.length-1"
                 mat-mini-fab
                 title="Move down"
                 color="primary"

--- a/src/app/workflow-spec-list/workflow-spec-list.component.html
+++ b/src/app/workflow-spec-list/workflow-spec-list.component.html
@@ -59,7 +59,7 @@
         <mat-divider></mat-divider>
 
       <mat-accordion class="example-headers-align" multi="false">
-      <ng-container *ngFor="let cat of workflowSpecsByCategory">
+      <ng-container *ngFor="let cat of workflowSpecsByCategory; let j = index">
 
         <div *ngIf="!(searchField.value && cat.workflow_specs.length === 0)">
         <ng-container *ngIf="!(cat.id === null && cat.workflow_specs.length === 0)">
@@ -110,20 +110,20 @@
                 <mat-icon>edit</mat-icon>
               </button>
               <button
-                *ngIf="!cat[0]"
+                *ngIf="j!==1"
                 mat-mini-fab
                 title="Move up"
                 color="primary"
-                (click)="editCategoryDisplayOrder(cat.id, -1)"
+                (click)="editCategoryDisplayOrder(cat, cat.id, 'up')"
               >
                 <mat-icon>arrow_upward</mat-icon>
               </button>
               <button
-                *ngIf="!cat[workflowSpecsByCategory.length-1]"
+                *ngIf="j!== cat[workflowSpecsByCategory.length-1]"
                 mat-mini-fab
                 title="Move down"
                 color="primary"
-                (click)="editCategoryDisplayOrder(cat.id, 1)"
+                (click)="editCategoryDisplayOrder(cat, cat.id, 'down')"
               >
                 <mat-icon>arrow_downward</mat-icon>
               </button>

--- a/src/app/workflow-spec-list/workflow-spec-list.component.spec.ts
+++ b/src/app/workflow-spec-list/workflow-spec-list.component.spec.ts
@@ -15,7 +15,7 @@ import {of} from 'rxjs';
 import {
   ApiErrorsComponent,
   ApiService,
-  MockEnvironment,
+  MockEnvironment, mockWorkflowMeta1,
   mockWorkflowSpec0,
   mockWorkflowSpec1,
   mockWorkflowSpec2,
@@ -36,7 +36,7 @@ import {
 } from '../_interfaces/dialog-data';
 import {GetIconCodePipe} from '../_pipes/get-icon-code.pipe';
 import {FileListComponent} from '../file-list/file-list.component';
-import {WorkflowSpecListComponent} from './workflow-spec-list.component';
+import {WorkflowSpecCategoryGroup, WorkflowSpecListComponent} from './workflow-spec-list.component';
 
 
 export class MdDialogMock {
@@ -476,33 +476,25 @@ describe('WorkflowSpecListComponent', () => {
   });
    */
 
-  it('should update all category display orders', () => {
-    const editCategoryDisplayOrderSpy = spyOn((component as any), 'editCategoryDisplayOrder').and.stub();
-
-    mockWorkflowSpecCategories.forEach((cat, i) => {
-      let results = { param: 'direction', value: 'down' };
-      const req = httpMock.expectOne(`apiRoot/workflow-specification-category/${cat.id}/reorder?${results.param}=${results.value}`);
-      expect(req.request.method).toEqual('PUT');
-      req.flush(mockWorkflowSpecCategories[i]);
-    });
-
-    expect(editCategoryDisplayOrderSpy).toHaveBeenCalled();
+  it('should update a single category display order', () => {
+    mockWorkflowSpecCategory1.id = 5;
+    (component as any).editCategoryDisplayOrder(mockWorkflowSpecCategory1.id, 'down');
+    let results = { param: 'direction', value: 'down' };
+    const req = httpMock.expectOne(`apiRoot/workflow-specification-category/${mockWorkflowSpecCategory1.id}/reorder?${results.param}=${results.value}`);
+    expect(req.request.method).toEqual('PUT');
+    req.flush(mockWorkflowSpecCategory1);
   });
-  /**
 
-  it('should update all spec display orders', () => {
-    const _loadWorkflowSpecCategoriesSpy = spyOn((component as any), '_loadWorkflowSpecCategories').and.stub();
-
-    mockWorkflowSpecs.forEach((spec, i) => {
-      const req = httpMock.expectOne(`apiRoot/workflow-specification/${spec.id}`);
-      expect(req.request.method).toEqual('PUT');
-      req.flush(mockWorkflowSpecs[i]);
-    });
-
-    expect(_loadWorkflowSpecCategoriesSpy).toHaveBeenCalled();
+  it('should update a single spec display order', () => {
+    let wfs_group: WorkflowSpecCategoryGroup[] = [];
+    mockWorkflowSpecCategory1.workflows.push(mockWorkflowMeta1);
+    wfs_group.push(mockWorkflowSpecCategory1);
+    (component as any).editSpecDisplayOrder(wfs_group[0], mockWorkflowSpec1.id, 'down');
+    let results = { param: 'direction', value: 'down' };
+    const req = httpMock.expectOne(`apiRoot/workflow-specification/${mockWorkflowSpec1.id}/reorder?${results.param}=${results.value}`);
+    expect(req.request.method).toEqual('PUT');
+    req.flush(mockWorkflowSpecCategory1);
   });
-   */
-
 
 
   it('should load master workflow spec', () => {

--- a/src/app/workflow-spec-list/workflow-spec-list.component.spec.ts
+++ b/src/app/workflow-spec-list/workflow-spec-list.component.spec.ts
@@ -391,23 +391,28 @@ describe('WorkflowSpecListComponent', () => {
 
   });
 
+  /**
+   *  Deprecated - removed reorder and ability to directly edit display order
+   *
   it('should edit category display order', () => {
-    const _reorderSpy = spyOn((component as any), '_reorder').and.stub();
+    // const _reorderSpy = spyOn((component as any), '_reorder').and.stub();
     const _updateCatDisplayOrdersSpy = spyOn((component as any), '_updateCatDisplayOrders').and.stub();
 
     component.editCategoryDisplayOrder(2, -1, mockWorkflowSpecCategories);
-    expect(_reorderSpy).toHaveBeenCalled();
+    // expect(_reorderSpy).toHaveBeenCalled();
     expect(_updateCatDisplayOrdersSpy).toHaveBeenCalled();
   });
 
+
   it('should edit workflow spec display order', () => {
-    const _reorderSpy = spyOn((component as any), '_reorder').and.stub();
+    // const _reorderSpy = spyOn((component as any), '_reorder').and.stub();
     const _updateSpecDisplayOrdersSpy = spyOn((component as any), '_updateSpecDisplayOrders').and.stub();
 
     component.editSpecDisplayOrder('few_things', -1, mockWorkflowSpecs);
-    expect(_reorderSpy).toHaveBeenCalled();
+    // expect(_reorderSpy).toHaveBeenCalled();
     expect(_updateSpecDisplayOrdersSpy).toHaveBeenCalled();
   });
+
 
   it('should reorder categories', () => {
     const snackBarSpy = spyOn((component as any).snackBar, 'open').and.stub();
@@ -436,6 +441,7 @@ describe('WorkflowSpecListComponent', () => {
     expect(moveUpSpy).not.toHaveBeenCalled();
     expect(moveDownSpy).toHaveBeenCalled();
   });
+
 
   it('should reorder specs', () => {
     const snackBarSpy = spyOn((component as any).snackBar, 'open').and.stub();
@@ -468,23 +474,24 @@ describe('WorkflowSpecListComponent', () => {
     expect(moveUpSpy).not.toHaveBeenCalled();
     expect(moveDownSpy).toHaveBeenCalled();
   });
+   */
 
   it('should update all category display orders', () => {
-    const _loadWorkflowSpecCategoriesSpy = spyOn((component as any), '_loadWorkflowSpecCategories').and.stub();
-    (component as any)._updateCatDisplayOrders(mockWorkflowSpecCategories);
+    const editCategoryDisplayOrderSpy = spyOn((component as any), 'editCategoryDisplayOrder').and.stub();
 
-    mockWorkflowSpecCategories.forEach((spec, i) => {
-      const req = httpMock.expectOne(`apiRoot/workflow-specification-category/${spec.id}`);
+    mockWorkflowSpecCategories.forEach((cat, i) => {
+      let results = { param: 'direction', value: 'down' };
+      const req = httpMock.expectOne(`apiRoot/workflow-specification-category/${cat.id}/reorder?${results.param}=${results.value}`);
       expect(req.request.method).toEqual('PUT');
       req.flush(mockWorkflowSpecCategories[i]);
     });
 
-    expect(_loadWorkflowSpecCategoriesSpy).toHaveBeenCalled();
+    expect(editCategoryDisplayOrderSpy).toHaveBeenCalled();
   });
+  /**
 
   it('should update all spec display orders', () => {
     const _loadWorkflowSpecCategoriesSpy = spyOn((component as any), '_loadWorkflowSpecCategories').and.stub();
-    (component as any)._updateSpecDisplayOrders(mockWorkflowSpecs);
 
     mockWorkflowSpecs.forEach((spec, i) => {
       const req = httpMock.expectOne(`apiRoot/workflow-specification/${spec.id}`);
@@ -494,6 +501,7 @@ describe('WorkflowSpecListComponent', () => {
 
     expect(_loadWorkflowSpecCategoriesSpy).toHaveBeenCalled();
   });
+   */
 
 
 

--- a/src/app/workflow-spec-list/workflow-spec-list.component.ts
+++ b/src/app/workflow-spec-list/workflow-spec-list.component.ts
@@ -222,18 +222,20 @@ export class WorkflowSpecListComponent implements OnInit {
     });
   }
 
-  editCategoryDisplayOrder(catId: number, direction: number) {
+  editCategoryDisplayOrder(catId: number, direction: string) {
     // const reorderedCats = this._reorder(catId, direction, cats) as WorkflowSpecCategoryGroup[];
     // this._updateCatDisplayOrders(reorderedCats);
 
     // Send this info to a new endpoint
   }
 
-  editSpecDisplayOrder(specId: string, direction: number) {
+  editSpecDisplayOrder(cat: WorkflowSpecCategoryGroup, specId: string, direction: string) {
     // const reorderedSpecs = this._reorder(specId, direction, specs) as WorkflowSpec[];
     // this._updateSpecDisplayOrders(reorderedSpecs);
-
-    // this.api.reorderWorkflowSpecification();
+    this.api.reorderWorkflowSpecification(specId, direction).subscribe(wfs => {
+      console.log('reorder');
+      // cat.workflow_specs= wfs;
+    });
   }
 
   // sortByDisplayOrder = (a, b) => (a.display_order < b.display_order) ? -1 : 1;

--- a/src/app/workflow-spec-list/workflow-spec-list.component.ts
+++ b/src/app/workflow-spec-list/workflow-spec-list.component.ts
@@ -233,7 +233,7 @@ export class WorkflowSpecListComponent implements OnInit {
     // const reorderedSpecs = this._reorder(specId, direction, specs) as WorkflowSpec[];
     // this._updateSpecDisplayOrders(reorderedSpecs);
 
-    this.api.reorderWorkflowSpecification();
+    // this.api.reorderWorkflowSpecification();
   }
 
   // sortByDisplayOrder = (a, b) => (a.display_order < b.display_order) ? -1 : 1;
@@ -241,6 +241,7 @@ export class WorkflowSpecListComponent implements OnInit {
   private _loadWorkflowSpecCategories(selectedSpecName: string = null) {
     this.api.getWorkflowSpecCategoryList().subscribe(cats => {
       // this.categories = cats.sort(this.sortByDisplayOrder);
+      this.categories = cats;
 
       // Add a container for specs without a category
       this.workflowSpecsByCategory = [{
@@ -401,9 +402,9 @@ export class WorkflowSpecListComponent implements OnInit {
  private _reorderWorkflowSpec(specId: string, direction: number) {
     //First, convert direction to string
     let d = (direction == -1) ? "moveUp" : "moveDown";
-    this.api.reorderWorkflowSpec(specId, d).subscribe(_ => {
+    // this.api.reorderWorkflowSpec(specId, d).subscribe(_ => {
       //subscribe to some stuff
-      });
+    //  });
  }
 
   private _displayMessage(message: string) {

--- a/src/app/workflow-spec-list/workflow-spec-list.component.ts
+++ b/src/app/workflow-spec-list/workflow-spec-list.component.ts
@@ -233,8 +233,7 @@ export class WorkflowSpecListComponent implements OnInit {
     // const reorderedSpecs = this._reorder(specId, direction, specs) as WorkflowSpec[];
     // this._updateSpecDisplayOrders(reorderedSpecs);
     this.api.reorderWorkflowSpecification(specId, direction).subscribe(wfs => {
-      console.log('reorder');
-      // cat.workflow_specs= wfs;
+      cat.workflow_specs= wfs;
     });
   }
 
@@ -254,7 +253,7 @@ export class WorkflowSpecListComponent implements OnInit {
         display_order: -1, // Display it at the top
       }];
 
-      // note - wonder if this could also go to backend
+      // ?
       this.categories.forEach((cat, i) => {
         this.workflowSpecsByCategory.push(cat);
         this.workflowSpecsByCategory[i + 1].workflow_specs = [];
@@ -270,8 +269,6 @@ export class WorkflowSpecListComponent implements OnInit {
     });
   }
 
-
-  // Need to step thru this
   private _loadWorkflowSpecs(selectedSpecName: string = null, searchSpecName: string = null) {
 
     this.api.getWorkflowSpecList().subscribe(wfs => {
@@ -318,7 +315,7 @@ export class WorkflowSpecListComponent implements OnInit {
         display_name: data.display_name,
         description: data.description,
         category_id: data.category_id,
-        display_order: data.display_order,
+        // display_order: data.display_order,
         standalone: data.standalone,
         library: data.library,
       };
@@ -397,23 +394,13 @@ export class WorkflowSpecListComponent implements OnInit {
     });
   }
 
-  private _reorderWorkflowSpecCategory() {
-    //wip
- }
-
- private _reorderWorkflowSpec(specId: string, direction: number) {
-    //First, convert direction to string
-    let d = (direction == -1) ? "moveUp" : "moveDown";
-    // this.api.reorderWorkflowSpec(specId, d).subscribe(_ => {
-      //subscribe to some stuff
-    //  });
- }
-
   private _displayMessage(message: string) {
     this.snackBar.open(message, 'Ok', {duration: 3000});
   }
 
   /**
+   *  Deprecated - backend now reorders
+   *
   private _reorder(
     id: number | string, direction: number,
     list: Array<WorkflowSpecCategoryGroup | WorkflowSpec>,
@@ -436,6 +423,9 @@ export class WorkflowSpecListComponent implements OnInit {
   }
    **/
 
+  /**
+   * Deprecated - backend updates display_order
+   *
   private _updateCatDisplayOrders(cats: WorkflowSpecCategory[]) {
     let numUpdated = 0;
     cats.forEach((cat, j) => {
@@ -453,6 +443,7 @@ export class WorkflowSpecListComponent implements OnInit {
       }
     });
   }
+
 
   private _updateSpecDisplayOrders(specs: WorkflowSpec[]) {
     if (this.selectedCat && this.selectedSpec.category) {
@@ -472,7 +463,7 @@ export class WorkflowSpecListComponent implements OnInit {
       });
     });
   }
-
+   */
 
 }
 

--- a/src/app/workflow-spec-list/workflow-spec-list.component.ts
+++ b/src/app/workflow-spec-list/workflow-spec-list.component.ts
@@ -222,16 +222,16 @@ export class WorkflowSpecListComponent implements OnInit {
     });
   }
 
-  editCategoryDisplayOrder(catId: number, direction: string) {
-    // const reorderedCats = this._reorder(catId, direction, cats) as WorkflowSpecCategoryGroup[];
-    // this._updateCatDisplayOrders(reorderedCats);
-
-    // Send this info to a new endpoint
+  editCategoryDisplayOrder(cat: WorkflowSpecCategoryGroup, catId: number, direction: string) {
+    this.api.reorderWorkflowCategory(catId, direction).subscribe(cat_change => {
+      console.log('wfsbcat: ', this.workflowSpecsByCategory);
+      console.log('this.categories', this.categories);
+      console.log('changed is ', cat_change);
+      // this.workflowSpecsByCategory = cat_change;
+    });
   }
 
   editSpecDisplayOrder(cat: WorkflowSpecCategoryGroup, specId: string, direction: string) {
-    // const reorderedSpecs = this._reorder(specId, direction, specs) as WorkflowSpec[];
-    // this._updateSpecDisplayOrders(reorderedSpecs);
     this.api.reorderWorkflowSpecification(specId, direction).subscribe(wfs => {
       cat.workflow_specs= wfs;
     });
@@ -253,7 +253,6 @@ export class WorkflowSpecListComponent implements OnInit {
         display_order: -1, // Display it at the top
       }];
 
-      // ?
       this.categories.forEach((cat, i) => {
         this.workflowSpecsByCategory.push(cat);
         this.workflowSpecsByCategory[i + 1].workflow_specs = [];

--- a/src/app/workflow-spec-list/workflow-spec-list.component.ts
+++ b/src/app/workflow-spec-list/workflow-spec-list.component.ts
@@ -224,6 +224,8 @@ export class WorkflowSpecListComponent implements OnInit {
 
   editCategoryDisplayOrder(catId: number, direction: string) {
     this.api.reorderWorkflowCategory(catId, direction).subscribe(cat_change => {
+      console.log('old wfsbycat is: ', this.workflowSpecsByCategory);
+      console.log('new wfsbycat is: ', cat_change);
       this.workflowSpecsByCategory = cat_change;
     });
   }
@@ -242,6 +244,9 @@ export class WorkflowSpecListComponent implements OnInit {
       this.categories = cats;
 
       // Add a container for specs without a category
+      /**
+       * Deprecated - no more 'None'
+       *
       this.workflowSpecsByCategory = [{
         id: null,
         name: 'none',
@@ -249,10 +254,11 @@ export class WorkflowSpecListComponent implements OnInit {
         workflow_specs: [],
         display_order: -1, // Display it at the top
       }];
+       */
 
       this.categories.forEach((cat, i) => {
         this.workflowSpecsByCategory.push(cat);
-        this.workflowSpecsByCategory[i + 1].workflow_specs = [];
+        this.workflowSpecsByCategory[i].workflow_specs = [];
       });
       this._loadWorkflowSpecs(selectedSpecName);
       this._loadWorkflowLibraries();

--- a/src/app/workflow-spec-list/workflow-spec-list.component.ts
+++ b/src/app/workflow-spec-list/workflow-spec-list.component.ts
@@ -148,9 +148,9 @@ export class WorkflowSpecListComponent implements OnInit {
     dialogRef.afterClosed().subscribe((data: WorkflowSpecDialogData) => {
       if (data && data.id && data.name && data.display_name && data.description) {
         if (this.canSaveWorkflowSpec(data)) {
-          data.display_order = this.categories.filter(function (entry) {
-            return entry.id === data.category_id;
-          }).length;
+          // data.display_order = this.categories.filter(function (entry) {
+          //   return entry.id === data.category_id;
+          // }).length;
           this._upsertWorkflowSpecification(selectedSpec == null, data);
         }
       }
@@ -222,21 +222,25 @@ export class WorkflowSpecListComponent implements OnInit {
     });
   }
 
-  editCategoryDisplayOrder(catId: number, direction: number, cats: WorkflowSpecCategoryGroup[]) {
-    const reorderedCats = this._reorder(catId, direction, cats) as WorkflowSpecCategoryGroup[];
-    this._updateCatDisplayOrders(reorderedCats);
+  editCategoryDisplayOrder(catId: number, direction: number) {
+    // const reorderedCats = this._reorder(catId, direction, cats) as WorkflowSpecCategoryGroup[];
+    // this._updateCatDisplayOrders(reorderedCats);
+
+    // Send this info to a new endpoint
   }
 
-  editSpecDisplayOrder(specId: string, direction: number, specs: WorkflowSpec[]) {
-    const reorderedSpecs = this._reorder(specId, direction, specs) as WorkflowSpec[];
-    this._updateSpecDisplayOrders(reorderedSpecs);
+  editSpecDisplayOrder(specId: string, direction: number) {
+    // const reorderedSpecs = this._reorder(specId, direction, specs) as WorkflowSpec[];
+    // this._updateSpecDisplayOrders(reorderedSpecs);
+
+    this.api.reorderWorkflowSpecification();
   }
 
-  sortByDisplayOrder = (a, b) => (a.display_order < b.display_order) ? -1 : 1;
+  // sortByDisplayOrder = (a, b) => (a.display_order < b.display_order) ? -1 : 1;
 
   private _loadWorkflowSpecCategories(selectedSpecName: string = null) {
     this.api.getWorkflowSpecCategoryList().subscribe(cats => {
-      this.categories = cats.sort(this.sortByDisplayOrder);
+      // this.categories = cats.sort(this.sortByDisplayOrder);
 
       // Add a container for specs without a category
       this.workflowSpecsByCategory = [{
@@ -247,6 +251,7 @@ export class WorkflowSpecListComponent implements OnInit {
         display_order: -1, // Display it at the top
       }];
 
+      // note - wonder if this could also go to backend
       this.categories.forEach((cat, i) => {
         this.workflowSpecsByCategory.push(cat);
         this.workflowSpecsByCategory[i + 1].workflow_specs = [];
@@ -257,13 +262,13 @@ export class WorkflowSpecListComponent implements OnInit {
   }
 
   private _loadWorkflowLibraries() {
-
     this.api.getWorkflowSpecificationLibraries().subscribe(wfs => {
       this.workflowLibraries = wfs;
     });
   }
 
 
+  // Need to step thru this
   private _loadWorkflowSpecs(selectedSpecName: string = null, searchSpecName: string = null) {
 
     this.api.getWorkflowSpecList().subscribe(wfs => {
@@ -271,6 +276,7 @@ export class WorkflowSpecListComponent implements OnInit {
       this.workflowSpecsByCategory.forEach(cat => {
         cat.workflow_specs = this.workflowSpecs
           .filter(wf => {
+            // Find and set master spec
             if (wf.is_master_spec) {
               this.masterStatusSpec = wf;
             } else {
@@ -281,7 +287,7 @@ export class WorkflowSpecListComponent implements OnInit {
               }
             }
           })
-          .sort(this.sortByDisplayOrder);
+          // .sort(this.sortByDisplayOrder);
       });
 
       // Set the selected workflow to something sensible.
@@ -313,6 +319,7 @@ export class WorkflowSpecListComponent implements OnInit {
         standalone: data.standalone,
         library: data.library,
       };
+      console.log('DO: ', data.display_order);
 
       if (isNew) {
         this._addWorkflowSpec(newSpec);
@@ -387,10 +394,23 @@ export class WorkflowSpecListComponent implements OnInit {
     });
   }
 
+  private _reorderWorkflowSpecCategory() {
+    //wip
+ }
+
+ private _reorderWorkflowSpec(specId: string, direction: number) {
+    //First, convert direction to string
+    let d = (direction == -1) ? "moveUp" : "moveDown";
+    this.api.reorderWorkflowSpec(specId, d).subscribe(_ => {
+      //subscribe to some stuff
+      });
+ }
+
   private _displayMessage(message: string) {
     this.snackBar.open(message, 'Ok', {duration: 3000});
   }
 
+  /**
   private _reorder(
     id: number | string, direction: number,
     list: Array<WorkflowSpecCategoryGroup | WorkflowSpec>,
@@ -411,6 +431,7 @@ export class WorkflowSpecListComponent implements OnInit {
       return [];
     }
   }
+   **/
 
   private _updateCatDisplayOrders(cats: WorkflowSpecCategory[]) {
     let numUpdated = 0;

--- a/src/app/workflow-spec-list/workflow-spec-list.component.ts
+++ b/src/app/workflow-spec-list/workflow-spec-list.component.ts
@@ -7,8 +7,8 @@ import {
   ApiErrorsComponent,
   ApiService,
   isNumberDefined,
-  moveArrayElementDown,
-  moveArrayElementUp,
+  // moveArrayElementDown,
+  // moveArrayElementUp,
   WorkflowSpec,
   WorkflowSpecCategory,
 } from 'sartography-workflow-lib';
@@ -52,8 +52,8 @@ export class WorkflowSpecListComponent implements OnInit {
   selectedCat: WorkflowSpecCategory;
   workflowSpecsByCategory: WorkflowSpecCategoryGroup[] = [];
   categories: WorkflowSpecCategory[];
-  moveUp = moveArrayElementUp;
-  moveDown = moveArrayElementDown;
+  // moveUp = moveArrayElementUp;
+  // moveDown = moveArrayElementDown;
   searchField: FormControl;
 
   constructor(
@@ -222,12 +222,9 @@ export class WorkflowSpecListComponent implements OnInit {
     });
   }
 
-  editCategoryDisplayOrder(cat: WorkflowSpecCategoryGroup, catId: number, direction: string) {
+  editCategoryDisplayOrder(catId: number, direction: string) {
     this.api.reorderWorkflowCategory(catId, direction).subscribe(cat_change => {
-      console.log('wfsbcat: ', this.workflowSpecsByCategory);
-      console.log('this.categories', this.categories);
-      console.log('changed is ', cat_change);
-      // this.workflowSpecsByCategory = cat_change;
+      this.workflowSpecsByCategory = cat_change;
     });
   }
 


### PR DESCRIPTION
All tests should be passing. This correctly resorts categories and specs, the arrows work, the display order is correctly updated, the categories and specs don't collapse down when the reorder endpoint is called. The only thing this does wrong, is pull libraries and standalones into categories- but that's the next ticket.