### PR TITLE
Sorta Fixes #479 - Issue deleting Library Workflow Specification

### DIFF
--- a/src/app/workflow-spec-list/workflow-spec-list.component.spec.ts
+++ b/src/app/workflow-spec-list/workflow-spec-list.component.spec.ts
@@ -535,68 +535,6 @@ describe('WorkflowSpecListComponent', () => {
     }
   ));
 
-  it('should disallow deselecting library if being used as library', () => {
-    let mockSpecData: WorkflowSpecDialogData = {
-      id: '25',
-      display_name: 'displayname',
-      description: 'descr',
-      category_id: 0,
-      display_order: 0,
-      standalone: false,
-      library: false
-    };
-
-    const _upsertWorkflowSpecificationSpy = spyOn((component as any), '_upsertWorkflowSpecification')
-      .and.stub();
-    const openDialogSpy = spyOn(component.dialog, 'open')
-      .and.returnValue({afterClosed: () => of(mockSpecData)} as any);
-    const canSaveSpy = spyOn(component, 'canSaveWorkflowSpec').and.callThrough();
-    const snackBarSpy = spyOn((component as any).snackBar, 'open').and.stub();
-    const localSelectedSpec = cloneDeep(mockWorkflowSpec0);
-    localSelectedSpec.parents = [
-      { id: 1234,
-        display_name: 'test parent',
-      }]
-    component.selectedSpec = localSelectedSpec;
-    component.editWorkflowSpec(localSelectedSpec);
-    expect(openDialogSpy).toHaveBeenCalled();
-    expect(_upsertWorkflowSpecificationSpy).not.toHaveBeenCalled();
-    expect(canSaveSpy).toHaveBeenCalled();
-    expect(snackBarSpy).toHaveBeenCalled();
-  });
-
-  it('should disallow saving as both library and standalone', () => {
-    // we need to have id,name and display_name filled out because there is a conditional
-    // that fails prior to saving if any of these are blank
-    let mockSpecData: WorkflowSpecDialogData = {
-      id: '25',
-      display_name: 'displayname',
-      description: 'descr',
-      category_id: 0,
-      display_order: 0,
-      standalone: true,
-      library: true
-    };
-
-    const _upsertWorkflowSpecificationSpy = spyOn((component as any), '_upsertWorkflowSpecification')
-      .and.stub();
-    const openDialogSpy = spyOn(component.dialog, 'open')
-      .and.returnValue({afterClosed: () => of(mockSpecData)} as any);
-    const canSaveSpy = spyOn(component, 'canSaveWorkflowSpec').and.callThrough();
-    const snackBarSpy = spyOn((component as any).snackBar, 'open').and.stub();
-    const localSelectedSpec = cloneDeep(mockWorkflowSpec0);
-    localSelectedSpec.parents = [
-      { id: 1234,
-        display_name: 'test parent',
-      }]
-    component.selectedSpec = localSelectedSpec;
-    component.editWorkflowSpec(localSelectedSpec);
-    expect(openDialogSpy).toHaveBeenCalled();
-    expect(_upsertWorkflowSpecificationSpy).not.toHaveBeenCalled();
-    expect(canSaveSpy).toHaveBeenCalled();
-    expect(snackBarSpy).toHaveBeenCalled();
-  });
-
   it('should not delete a library if it is being used', () => {
 
     const badWorkflowSpec = cloneDeep(mockWorkflowSpec0);

--- a/src/app/workflow-spec-list/workflow-spec-list.component.ts
+++ b/src/app/workflow-spec-list/workflow-spec-list.component.ts
@@ -106,23 +106,6 @@ export class WorkflowSpecListComponent implements OnInit {
     this.location.replaceState(environment.homeRoute + '/' + selectedSpec.id);
   }
 
-  categoryExpanded(cat: WorkflowSpecCategory) {
-    return this.selectedSpec != null && this.selectedSpec.category_id === cat.id;
-  }
-
-  canSaveWorkflowSpec(proposed: WorkflowSpecDialogData){
-    // Can possibly remove or bypass this method alltogether
-    if ((this.selectedSpec.parents.length > 0) && (!proposed.library)){
-      this.snackBar.open('This Workflow Specification is still being used as a Library. Please remove references first!', 'Ok', { duration: 5000 });
-      return false;
-    }
-    if (proposed.standalone && proposed.library){
-      this.snackBar.open('A workflow spec cannot be both a standalone and a library!', 'Ok', { duration: 5000 });
-      return false;
-    }
-    return true;
-  }
-
   editWorkflowSpec(state: String, selectedSpec?: WorkflowSpec) {
 
     const hasDisplayOrder = selectedSpec && isNumberDefined(selectedSpec.display_order);
@@ -147,9 +130,7 @@ export class WorkflowSpecListComponent implements OnInit {
       if (data.id) {
         data.id = this.toLowercaseId(data.id);
         if (data && data.id && data.display_name && data.description) {
-          if (this.canSaveWorkflowSpec(data)) {
-            this._upsertWorkflowSpecification(selectedSpec == null, data);
-          }
+          this._upsertWorkflowSpecification(selectedSpec == null, data);
         }
       }
     });
@@ -199,7 +180,13 @@ export class WorkflowSpecListComponent implements OnInit {
 
   canDeleteWorkflowSpec(wfs){
     if ((wfs.parents.length > 0) && (wfs.library)){
-      this.snackBar.open('This Workflow Specification is still being used as a Library. Please remove references first!', 'Ok', { duration: 5000 });
+      let message = '';
+      for (let p of wfs.parents) {
+        message += p.display_name + ', ';
+      }
+      message = message.replace(/,\s*$/, "");
+      this.snackBar.open('The Library ' + '\'' + wfs.display_name + '\'' +
+        ' is still being referenced by these workflows: ' + message, 'Ok');
       return false;
     }
     return true;


### PR DESCRIPTION
Displays library references when you attempt to delete a library, if there are any. I also removed deprecated methods. And their tests. (You can't even try to save something in a bad state because you only get the option to generate it in a good state)